### PR TITLE
+ Unpivot function.

### DIFF
--- a/src/Core/Query.cs
+++ b/src/Core/Query.cs
@@ -37,7 +37,7 @@ namespace WebLinq
                                  .ToQuery();
         }
         
-        public static SeqQuery<T[]> Unpivot<T>(IEnumerable<IEnumerable<T>> source, Func<IEnumerable<T>, int, bool> pHeader, int fromColumn, int toColumn)
+        public static Query<T[]> Unpivot<T>(IEnumerable<IEnumerable<T>> source, Func<IEnumerable<T>, int, bool> pHeader, int fromColumn, int toColumn)
         {
             return UnpivotImpl(source, pHeader, fromColumn, toColumn).ToQuery();
         }


### PR DESCRIPTION
This function provides a generic solution to the problem of unpivoting extracted data.
Typically the generic parameter <code>T</code> will be <code>string</code> or <code>object</code> depending on how the data has been extracted.