### PR TITLE
Fix: by initializing empty HeaderCollection was ignoring existing ones.

### DIFF
--- a/src/Core/HttpSpec.cs
+++ b/src/Core/HttpSpec.cs
@@ -61,7 +61,7 @@ namespace WebLinq
 
         HttpOptions Options(string ua)
         {
-            var headers = HttpHeaderCollection.Empty;
+            var headers = Headers;
             if (!string.IsNullOrEmpty(ua) && (Headers.IsEmpty || Headers.TryGetValue("User-Agent") == null))
                 headers = headers.Set("User-Agent", ua);
 


### PR DESCRIPTION
Now it copies the existing headers.
Before all per-request headers were never sent.